### PR TITLE
Fixed issue with destructuring props object

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ const setupHref = (props) => {
   let href = "";
   if (compat.IS_AR_QUICKLOOK_CANDIDATE) {
     const {
-      iosSrc,
+      "ios-src": iosSrc,
       applePayButtonType,
       checkoutTitle,
       checkoutSubtitle,


### PR DESCRIPTION
I was having trouble getting an example to work until I made this small edit, fixing an error in which you were destructuring an object with a key that had a hyphen in it (`ios-src`), which was causing `iosSrc` to return as `undefined` instead of a string for the URL.

It seems to work after this small change.