### PR TITLE
Fixed issue with `window.MSStream`, updated docs.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,7 @@
 // trigger on an user interaction, like a click
 activateAR({
   src: "https://github.com/leoncvlt/ar-button/raw/master/assets/Astronaut.glb"
-  ios-src: "https://github.com/leoncvlt/ar-button/raw/master/assets/Astronaut.usdz"
+  iosSrc: "https://github.com/leoncvlt/ar-button/raw/master/assets/Astronaut.usdz"
   link: "https://www.nasa.gov/"
   title: "A 3D model of an astronaut
 })</code></pre>

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ const setupHref = (props) => {
   let href = "";
   if (compat.IS_AR_QUICKLOOK_CANDIDATE) {
     const {
-      iosSrc,
+      "ios-src": iosSrc,
       applePayButtonType,
       checkoutTitle,
       checkoutSubtitle,

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ export const compat = {
   // @see https://forums.developer.apple.com/thread/119186
   // @see https://github.com/google/model-viewer/issues/758
   IS_IOS:
-    (/iPad|iPhone|iPod/.test(navigator.userAgent) && !MSStream) ||
+    (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream) ||
     (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1),
 
   IS_AR_QUICKLOOK_CANDIDATE: (() => {
@@ -74,9 +74,10 @@ export const activateAR = (props, listener) => {
 
 const setupHref = (props) => {
   let href = "";
+
   if (compat.IS_AR_QUICKLOOK_CANDIDATE) {
     const {
-      "ios-src": iosSrc,
+      iosSrc,
       applePayButtonType,
       checkoutTitle,
       checkoutSubtitle,

--- a/index.js
+++ b/index.js
@@ -52,14 +52,19 @@ export const compat = {
 export const activateAR = (props, listener) => {
   const anchor = document.createElement("a");
   const href = setupHref(props);
+  anchor.setAttribute("href", href);
+  anchor.style.display = 'none';
+
   if (compat.IS_AR_QUICKLOOK_CANDIDATE) {
     // quick look needs a <img> child to go directly to AR view
     anchor.appendChild(document.createElement("img"));
     anchor.rel = "ar";
   }
-  anchor.setAttribute("href", href);
-  anchor.click();
+
   if (listener && compat.IS_AR_QUICKLOOK_CANDIDATE) {
+    // anchor needs to be added to the body before you can add an event listener
+    document.body.append(anchor)
+
     anchor.addEventListener(
       "message",
       (event) => {
@@ -68,8 +73,10 @@ export const activateAR = (props, listener) => {
         }
       },
       false
-    );
-  }
+      );
+    }
+
+    anchor.click();
 };
 
 const setupHref = (props) => {


### PR DESCRIPTION
1. I was having trouble getting an example to work, but as suggested by @eemaano, [changing one line the in `compat` function seems to get things working again.](https://github.com/leoncvlt/ar-button/issues/2#issuecomment-1427965596)

2. I also updated the `activateAR` example in the docs:

```
import { activateAR } from "@leoncvlt/ar-button";

// trigger on an user interaction, like a click
activateAR({
  src: "https://github.com/leoncvlt/ar-button/raw/master/assets/Astronaut.glb"
  ios-src: "https://github.com/leoncvlt/ar-button/raw/master/assets/Astronaut.usdz"
  link: "https://www.nasa.gov/"
  title: "A 3D model of an astronaut
})
```

The code in the docs (shown above) doesn't seem to work, because the hyphenated `ios-src` key being destructured returns `undefined`. Using `iosSrc` instead will allow the model to load correctly.